### PR TITLE
docs(quickstart): link updated for Auth Token page

### DIFF
--- a/documentation/guides/quickstart.mdx
+++ b/documentation/guides/quickstart.mdx
@@ -92,7 +92,7 @@ hmsInstance.addEventListener(HMSUpdateListenerActions.ON_JOIN, onJoin);
 To join a room 3 fields are required:
 
 - `username`: The name of the user. This is the value that will be set on the peer object and be visible to everyone connected to the room.
-- `authToken`: A client-side token that is used to authenticate the user. You can read about how to generate this token [here](https://docs.100ms.live/react-native/guides/token).
+- `authToken`: A client-side token that is used to authenticate the user. You can read about how to generate this token [here](https://docs.100ms.live/react-native/v2/guides/token).
 - `userID`: A unique ID that will be used to identify user.
 - `roomID` (optional): The ID of the room that you wanna join
 


### PR DESCRIPTION
Problem
The link for **_Auth Token Quickstart Guide_** page present on [React Native Quickstart Guide](https://docs.100ms.live/javascript/v2/guides/react-quickstart) was not working. 

![Screenshot 2021-10-10 at 6 34 41 PM](https://user-images.githubusercontent.com/11802742/136697205-99af9cf3-8304-4ff4-bfd4-ec6040baf080.png)

After fix:
Now it redirects to the correct location
![image](https://user-images.githubusercontent.com/11802742/136697288-66f0346a-35c1-491d-b94d-6572de9d7193.png)

