### PR TITLE
feature(HMSSDK): Added optional type parameter in sendBroadcastMessage

### DIFF
--- a/src/classes/HMSSDK.ts
+++ b/src/classes/HMSSDK.ts
@@ -147,8 +147,8 @@ export default class HMSSDK {
     HmsManager.leave();
   };
 
-  sendBroadcastMessage = (message: String) => {
-    HmsManager.sendBroadcastMessage({ message });
+  sendBroadcastMessage = (message: String, type?: string) => {
+    HmsManager.sendBroadcastMessage({ message, type });
   };
 
   sendGroupMessage = (message: String, roles: HMSRole[]) => {


### PR DESCRIPTION
Added support for custom **`type`**  while broadcasting a message 
 
Example:
`instance.sendBroadcastMessage(value, 'emoji');`