### PR TITLE
callback for handling meeting leave

### DIFF
--- a/packages/react-native-room-kit/example/ios/Podfile.lock
+++ b/packages/react-native-room-kit/example/ios/Podfile.lock
@@ -79,7 +79,7 @@ PODS:
   - HMSBroadcastExtensionSDK (0.0.9)
   - HMSHLSPlayerSDK (0.0.2):
     - HMSAnalyticsSDK (= 0.0.2)
-  - HMSSDK (0.9.8):
+  - HMSSDK (0.9.9):
     - HMSAnalyticsSDK (= 0.0.2)
     - HMSWebRTC (= 1.0.5116)
   - HMSWebRTC (1.0.5116)
@@ -317,7 +317,7 @@ PODS:
   - react-native-hms (1.7.1):
     - HMSBroadcastExtensionSDK (= 0.0.9)
     - HMSHLSPlayerSDK (= 0.0.2)
-    - HMSSDK (= 0.9.8)
+    - HMSSDK (= 0.9.9)
     - React-Core
   - react-native-safe-area-context (3.3.0):
     - React-Core
@@ -649,7 +649,7 @@ SPEC CHECKSUMS:
   HMSAnalyticsSDK: 4d2a88a729b1eb42f3d25f217c28937ec318a5b7
   HMSBroadcastExtensionSDK: d80fe325f6c928bd8e5176290b5a4b7ae15d6fbb
   HMSHLSPlayerSDK: 6a54ad4d12f3dc2270d1ecd24019d71282a4f6a3
-  HMSSDK: 19df8bd7bb2ef517b3364983d96941996fdc65a0
+  HMSSDK: 4cf2a0a390a96f024b09c60dbb786d7a60800f6d
   HMSWebRTC: ae54e9dd91b869051b283b43b14f57d43b7bf8e1
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
@@ -670,7 +670,7 @@ SPEC CHECKSUMS:
   React-logger: a1f028f6d8639a3f364ef80419e5e862e1115250
   react-native-avoid-softinput: 71a692888f0c1d426ad9045dc8325773583962cd
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
-  react-native-hms: 7cf13ca7ad2a329c4b481ac9cda6d22226e8a762
+  react-native-hms: ace2195aab1e9fa7b7f265e5e436188da066b5c4
   react-native-safe-area-context: 61c8c484a3a9e7d1fda19f7b1794b35bbfd2262a
   react-native-simple-toast: bf002828cf816775a6809f7a9ec3907509bce11f
   React-perflogger: 0afaf2f01a47fd0fc368a93bfbb5bd3b26db6e7f

--- a/packages/react-native-room-kit/example/src/navigator/index.tsx
+++ b/packages/react-native-room-kit/example/src/navigator/index.tsx
@@ -8,20 +8,15 @@ import { QRCodeScanner } from '../screens/QRCodeScanner';
 import { HMSPrebuiltScreen } from '../screens/HMSPrebuiltScreen';
 
 export type AppStackParamList = {
-  WelcomeScreen: undefined;
-  MeetingScreen: { isHLSViewer: boolean };
   QRCodeScreen: undefined;
   QRCodeScannerScreen: undefined;
   HMSPrebuiltScreen: {
     roomCode: string;
     userName?: string;
     userId?: string;
-    endPoints?: { init: string; token: string };
     debugMode?: boolean;
-    ios?: {
-      appGroup?: string;
-      preferredExtension?: string;
-    };
+    initEndPoint?: string;
+    tokenEndPoint?: string;
   };
 };
 

--- a/packages/react-native-room-kit/example/src/screens/HMSPrebuiltScreen/index.tsx
+++ b/packages/react-native-room-kit/example/src/screens/HMSPrebuiltScreen/index.tsx
@@ -1,18 +1,51 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Text } from 'react-native';
-import { RouteProp, useRoute } from '@react-navigation/native';
+import { NavigationProp, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { HMSPrebuilt } from '@100mslive/react-native-room-kit';
+import type { HMSPrebuiltProps } from '@100mslive/react-native-room-kit';
 
 import { AppStackParamList } from '../../navigator';
 
 export const HMSPrebuiltScreen = () => {
-  const route = useRoute<RouteProp<AppStackParamList, 'HMSPrebuiltScreen'>>();
+  const navigation = useNavigation<NavigationProp<AppStackParamList>>();
+  const screenParams = useRoute<RouteProp<AppStackParamList, 'HMSPrebuiltScreen'>>().params;
 
-  const roomCode = route.params?.roomCode;
+  // function to be called when meeting is ended
+  const handleMeetingLeave = useCallback(() => {
+    navigation.navigate('QRCodeScreen');
+  }, []);
 
+  // room code of the HMSRoom
+  const roomCode = screenParams?.roomCode;
+
+  // HMSPrebuilt component options
+  const prebuiltOptions: HMSPrebuiltProps['options'] = useMemo(() => ({
+    userName: screenParams?.userName,
+    userId: screenParams?.userId,
+    debugMode: screenParams?.debugMode,
+    endPoints: screenParams?.tokenEndPoint && screenParams?.initEndPoint
+      ? {
+          token: screenParams?.tokenEndPoint,
+          init: screenParams?.initEndPoint
+        }
+      : undefined,
+    ios: {
+      appGroup: 'group.rnroomkit',
+      preferredExtension:
+        'live.100ms.reactnative.RNExampleBroadcastUpload',
+    },
+  }), [screenParams]);
+
+  // Room Code is required to join the room
   if (!roomCode) {
     return <Text>Room Code is Required</Text>;
   }
 
-  return <HMSPrebuilt roomCode={roomCode} options={route.params} />;
+  return (
+    <HMSPrebuilt
+      roomCode={roomCode}
+      options={prebuiltOptions}
+      onMeetingLeave={handleMeetingLeave}
+    />
+  );
 };

--- a/packages/react-native-room-kit/example/src/screens/QRCode/index.tsx
+++ b/packages/react-native-room-kit/example/src/screens/QRCode/index.tsx
@@ -79,16 +79,9 @@ const QRCode = () => {
           navigate('HMSPrebuiltScreen', {
             roomCode,
             userId,
-            endPoints:
-              tokenEndpoint && initEndpoint
-                ? { init: initEndpoint, token: tokenEndpoint }
-                : undefined,
+            initEndPoint: initEndpoint,
+            tokenEndPoint: tokenEndpoint,
             debugMode, // default is false, will deal with this later
-            ios: {
-              appGroup: 'group.rnroomkit',
-              preferredExtension:
-                'live.100ms.reactnative.RNExampleBroadcastUpload',
-            },
           });
         },
         (errorMsg: string) => {

--- a/packages/react-native-room-kit/example/src/screens/QRCodeScanner/index.tsx
+++ b/packages/react-native-room-kit/example/src/screens/QRCodeScanner/index.tsx
@@ -54,16 +54,9 @@ const QRCodeScanner = () => {
           navigate('HMSPrebuiltScreen', {
             roomCode,
             userId,
-            endPoints:
-              tokenEndpoint && initEndpoint
-                ? { init: initEndpoint, token: tokenEndpoint }
-                : undefined,
+            initEndPoint: initEndpoint,
+            tokenEndPoint: tokenEndpoint,
             debugMode, // default is false, will deal with this later
-            ios: {
-              appGroup: 'group.rnroomkit',
-              preferredExtension:
-                'live.100ms.reactnative.RNExampleBroadcastUpload',
-            },
           });
         },
         (errorMsg: string) => {

--- a/packages/react-native-room-kit/src/HMSPrebuilt.tsx
+++ b/packages/react-native-room-kit/src/HMSPrebuilt.tsx
@@ -22,12 +22,13 @@ export interface HMSPrebuiltProps {
     debugMode?: boolean;
     ios?: HMSIOSScreenShareConfig;
   };
+  onMeetingLeave?: () => void;
 }
 
 const _HMSPrebuilt: React.FC<HMSPrebuiltProps> = (props) => {
-  const { roomCode, options } = props;
+  const { roomCode, options, onMeetingLeave } = props;
 
-  store.dispatch(setPrebuiltData({ roomCode, options }));
+  store.dispatch(setPrebuiltData({ roomCode, options, onMeetingLeave }));
 
   // @ts-ignore Not using `useContext` hook because we don't want to subscribe to updates
   // We just want to check if SafeAreaProvider exists or not

--- a/packages/react-native-room-kit/src/redux/actions/index.ts
+++ b/packages/react-native-room-kit/src/redux/actions/index.ts
@@ -33,6 +33,7 @@ export const setPrebuiltData = (data: {
     };
     ios?: HMSIOSScreenShareConfig;
   };
+  onMeetingLeave?: () => void;
 }) => ({
   type: HmsStateActionTypes.SET_PREBUILT_DATA,
   payload: data,

--- a/packages/react-native-room-kit/src/redux/reducers/userState.ts
+++ b/packages/react-native-room-kit/src/redux/reducers/userState.ts
@@ -25,6 +25,7 @@ type IntialStateType = {
   isHLSFlow: boolean;
   roles: HMSRole[];
   iosBuildConfig: HMSIOSScreenShareConfig | null;
+  onMeetingLeave: (() => void) | undefined;
 };
 
 const INITIAL_STATE: IntialStateType = {
@@ -40,6 +41,7 @@ const INITIAL_STATE: IntialStateType = {
   hmsSessionStore: null,
   spotlightTrackId: null,
   iosBuildConfig: null,
+  onMeetingLeave: undefined,
 };
 
 const userReducer = (
@@ -76,6 +78,7 @@ const userReducer = (
       state.endPoints = action.payload.options.endPoints;
       state.debugMode = action.payload.options.debugMode ?? false;
       state.iosBuildConfig = action.payload.options.ios ?? null;
+      state.onMeetingLeave = action.payload.onMeetingLeave;
 
       return state;
     case HmsStateActionTypes.CLEAR_STATES:


### PR DESCRIPTION
# Description

This PR adds `onMeetingLeave` prop to `HMSPrebuilt` component. Users can pass a callback to `HMSPrebuilt` component using `onMeetingLeave` prop, and then the callback will be called when the meeting is ended or user is removed from the room.

User can use this callback to navigate app user to some screen on end of meeting.

```
const handleMeetingLeave = () => {
    navigation.navigate('<some screen>');
}

...

<HMSPrebuilt
    roomCode={"abc-defg-hij"}
    onMeetingLeave={handleMeetingLeave}
/>
```

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making, or this PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
