### PR TITLE
`isHLSViewer` variable is already declared error

### DIFF
--- a/packages/react-native-room-kit/src/components/Preview.tsx
+++ b/packages/react-native-room-kit/src/components/Preview.tsx
@@ -49,8 +49,6 @@ export const Preview = ({
   const canPublishVideo = useCanPublishVideo();
   const isHLSViewer = useIsHLSViewer();
 
-  const isHLSViewer = useIsHLSViewer();
-
   const hmsRoomStyles = useHMSRoomStyleSheet(
     (theme) => ({
       container: {


### PR DESCRIPTION
# Description

Fixes a bug which was added when solving merge conflict #1158 

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
