### PR TITLE
ios HLS Player memory leak issue resolved

### DIFF
--- a/packages/react-native-room-kit/src/components/PeerVideoTile/PeerVideoTileView.tsx
+++ b/packages/react-native-room-kit/src/components/PeerVideoTile/PeerVideoTileView.tsx
@@ -6,7 +6,6 @@ import {
   HMSVideoViewMode,
 } from '@100mslive/react-native-hms';
 import type { HMSView } from '@100mslive/react-native-hms';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { VideoView } from './VideoView';
@@ -164,16 +163,14 @@ export const _PeerVideoTileView = React.forwardRef<
             visible={mounted}
             onUnmount={hide}
           >
-            <Animated.View entering={FadeIn} exiting={FadeOut}>
-              <PressableIcon
-                activeOpacity={0.7}
-                style={[styles.iconWrapper, hmsRoomStyles.iconWrapperStyles]}
-                border={false}
-                onPress={handleOptionsPress}
-              >
-                <ThreeDotsIcon stack="vertical" style={styles.icon} />
-              </PressableIcon>
-            </Animated.View>
+            <PressableIcon
+              activeOpacity={0.7}
+              style={[styles.iconWrapper, hmsRoomStyles.iconWrapperStyles]}
+              border={false}
+              onPress={handleOptionsPress}
+            >
+              <ThreeDotsIcon stack="vertical" style={styles.icon} />
+            </PressableIcon>
           </UnmountAfterDelay>
         ) : (
           <PressableIcon


### PR DESCRIPTION
# Description

Fixed ios memory leak issue which was causing HLS player to exist even after user exits the room and since HLS player was still in memory, user could hear it's audio and on minimizing app, PIP window was also coming.

## Additional context

* Reanimated Layout animation was somehow keeping strong reference to `HmsDisplayView` component causing memory leak. Reanimated Layout animation was being used to wrap 3 dots button in peer video tile.

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
