### PR TITLE
fix: removed Right Aligning of Chat Messages

### DIFF
--- a/packages/react-native-room-kit/src/components/Chat/ChatMessage.tsx
+++ b/packages/react-native-room-kit/src/components/Chat/ChatMessage.tsx
@@ -11,7 +11,6 @@ interface HMSHLSMessageProps {
 
 const _ChatMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
   const messageSender = message.sender;
-  const isMessageSenderLocal = !!messageSender?.isLocal;
 
   const hmsRoomStyles = useHMSRoomStyleSheet(
     (theme, typography) => ({
@@ -36,14 +35,12 @@ const _ChatMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
       <View
         style={[
           styles.nameWrapper,
-          isMessageSenderLocal ? styles.nameWrapperAlignRight : null,
         ]}
       >
         <Text
           style={[
             styles.senderName,
             hmsRoomStyles.senderName,
-            isMessageSenderLocal ? styles.textAlignRight : null,
           ]}
           numberOfLines={1}
         >
@@ -58,7 +55,6 @@ const _ChatMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
           style={[
             styles.time,
             hmsRoomStyles.time,
-            isMessageSenderLocal ? styles.textAlignRight : null,
           ]}
         >
           {getTimeStringin12HourFormat(message.time)}
@@ -69,7 +65,6 @@ const _ChatMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
         style={[
           styles.message,
           hmsRoomStyles.message,
-          isMessageSenderLocal ? styles.textAlignRight : null,
         ]}
       >
         {message.message}
@@ -90,9 +85,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
   },
-  nameWrapperAlignRight: {
-    justifyContent: 'flex-end',
-  },
   senderName: {
     fontSize: 14,
     lineHeight: Platform.OS === 'android' ? 20 : undefined,
@@ -109,8 +101,5 @@ const styles = StyleSheet.create({
     lineHeight: Platform.OS === 'android' ? 20 : undefined,
     letterSpacing: 0.25,
     marginTop: 8,
-  },
-  textAlignRight: {
-    textAlign: 'right',
   },
 });

--- a/packages/react-native-room-kit/src/components/HMSHLSMessage.tsx
+++ b/packages/react-native-room-kit/src/components/HMSHLSMessage.tsx
@@ -34,7 +34,6 @@ const _HMSHLSMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
         style={[
           styles.senderName,
           hmsRoomStyles.senderName,
-          isMessageSenderLocal ? styles.textAlignRight : null,
         ]}
         numberOfLines={1}
       >
@@ -49,7 +48,6 @@ const _HMSHLSMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
         style={[
           styles.message,
           hmsRoomStyles.message,
-          isMessageSenderLocal ? styles.textAlignRight : null,
         ]}
       >
         {message.message}
@@ -79,8 +77,5 @@ const styles = StyleSheet.create({
     marginTop: 2,
     textShadowOffset: { height: 0.5, width: 0.5 },
     textShadowRadius: 2,
-  },
-  textAlignRight: {
-    textAlign: 'right',
   },
 });

--- a/packages/react-native-room-kit/src/components/HMSHLSMessage.tsx
+++ b/packages/react-native-room-kit/src/components/HMSHLSMessage.tsx
@@ -10,7 +10,6 @@ interface HMSHLSMessageProps {
 
 const _HMSHLSMessage: React.FC<HMSHLSMessageProps> = ({ message }) => {
   const messageSender = message.sender;
-  const isMessageSenderLocal = !!messageSender?.isLocal;
 
   const hmsRoomStyles = useHMSRoomStyleSheet(
     (_theme, typography) => ({


### PR DESCRIPTION
# Description

- removed Right Aligning of Chat Messages

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
