### PR TITLE
Fixed local tile creation logic

### DIFF
--- a/packages/react-native-room-kit/src/HMSRoomSetup.tsx
+++ b/packages/react-native-room-kit/src/HMSRoomSetup.tsx
@@ -218,6 +218,8 @@ export const HMSRoomSetup = () => {
         selectVideoTileLayoutConfig(currentLayoutConfig)?.grid
           ?.enable_local_tile_inset;
 
+      const canCreateTile = isPublishingAllowed(localPeer) && !isHLSViewer;
+
       batch(() => {
         const chatConfig = selectChatLayoutConfig(currentLayoutConfig);
         const overlayChatInitialState =
@@ -230,7 +232,7 @@ export const HMSRoomSetup = () => {
           dispatch({ type: 'SET_SHOW_CHAT_VIEW', showChatView: true });
         }
 
-        if (isPublishingAllowed(localPeer) && !isHLSViewer) {
+        if (canCreateTile) {
           if (reduxState.app.localPeerTrackNode) {
             dispatch(
               updateLocalPeerTrackNode({ peer, track: peer.videoTrack })
@@ -267,7 +269,7 @@ export const HMSRoomSetup = () => {
         }
 
         // setting local `PeerTrackNode` in regular peerTrackNodes array when inset tile is disabled
-        if (!enableLocalTileInset) {
+        if (!enableLocalTileInset && canCreateTile) {
           return [localPeerTrackNode, ...prevPeerTrackNodes];
         }
 

--- a/packages/react-native-room-kit/src/hooks-util.ts
+++ b/packages/react-native-room-kit/src/hooks-util.ts
@@ -337,7 +337,11 @@ const useHMSPeersUpdate = (
               miniviewPeerTrackNode.peer.peerID === peer.peerID
             ) {
               dispatch(updateMiniViewPeerTrackNode({ peer }));
-            } else if (miniviewPeerTrackNode === null) {
+            } else if (
+              miniviewPeerTrackNode === null &&
+              peer.role?.publishSettings?.allowed &&
+              peer.role.publishSettings.allowed.length > 0
+            ) {
               dispatch(
                 setMiniViewPeerTrackNode(
                   createPeerTrackNode(peer, peer.videoTrack)


### PR DESCRIPTION
# Description

Local tile (inset or regular) will be created when user can publish tracks

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
