### PR TITLE
Prebuilt: Fixed wrong role change on remove from stage 

### DIFF
--- a/packages/react-native-room-kit/src/components/Participants/ParticipantsItemOptions.tsx
+++ b/packages/react-native-room-kit/src/components/Participants/ParticipantsItemOptions.tsx
@@ -57,10 +57,13 @@ const _ParticipantsItemOptions: React.FC<ParticipantsItemOptionsProps> = ({
     return layoutConfig?.screens?.conferencing?.default?.elements?.on_stage_exp
       ?.off_stage_roles;
   });
-  const offStageRoleStr =
+  const firstOffStageRoleStr =
     offStageRoles && offStageRoles.length > 0 ? offStageRoles[0] : undefined;
+  const prevRoleStr = parseMetadata(peer.metadata).prevRole;
+
   const offStageRole = useSelector((state: RootState) => {
     const roles = state.hmsStates.roles;
+    const offStageRoleStr = prevRoleStr || firstOffStageRoleStr;
     return roles.find((role) => role.name === offStageRoleStr);
   });
 
@@ -112,7 +115,7 @@ const _ParticipantsItemOptions: React.FC<ParticipantsItemOptionsProps> = ({
         .then((d) => console.log('Remove from Stage Success: ', d))
         .catch((e) => console.log('Remove from Stage Error: ', e));
     } else {
-      console.warn(`offStageRole '${offStageRoleStr}' is ${offStageRole}`);
+      console.warn(`offStageRole '${prevRoleStr || firstOffStageRoleStr}' is ${offStageRole}`);
     }
     onItemPress();
   };

--- a/packages/react-native-room-kit/src/components/PreviewForRoleChangeModal.tsx
+++ b/packages/react-native-room-kit/src/components/PreviewForRoleChangeModal.tsx
@@ -40,6 +40,9 @@ const _PreviewForRoleChangeModal = () => {
   const localPeerName = useSelector(
     (state: RootState) => state.hmsStates.localPeer?.name || ''
   );
+  const localPeerRoleName = useSelector(
+    (state: RootState) => state.hmsStates.localPeer?.role?.name
+  );
   const localPeerMetadata = useSelector(
     (state: RootState) => parseMetadata(state.hmsStates.localPeer?.metadata),
     shallowEqual
@@ -144,6 +147,15 @@ const _PreviewForRoleChangeModal = () => {
 
   const handleRequestAccept = async () => {
     dispatch(setRoleChangeRequest(null));
+    // saving current role in peer metadata,
+    // so that when peer is removed from stage, we can assign previous role to it.
+    if (localPeerRoleName) {
+      const newMetadata = {
+        ...localPeerMetadata,
+        prevRole: localPeerRoleName,
+      };
+      await hmsActions.changeMetadata(newMetadata);
+    }
     await hmsInstance.acceptRoleChange();
   };
 

--- a/packages/react-native-room-kit/src/utils/functions.ts
+++ b/packages/react-native-room-kit/src/utils/functions.ts
@@ -54,6 +54,7 @@ export const parseMetadata = (
 ): {
   isHandRaised?: boolean;
   isBRBOn?: boolean;
+  prevRole?: string;
 } => {
   try {
     if (metadata) {


### PR DESCRIPTION
# Description

When a peer is removed from the stage, it should be assigned its previous role.

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
