### PR TITLE
bugfix/user stuck on "starting stream" screen

### DIFF
--- a/packages/react-native-room-kit/src/HMSRoomSetup.tsx
+++ b/packages/react-native-room-kit/src/HMSRoomSetup.tsx
@@ -133,6 +133,7 @@ export const HMSRoomSetup = () => {
       console.log('Start HLS Streaming Error: ', e);
       if (!ignoreHLSStreamPromise.current) {
         console.log('Unable to go live at the moment: ', e);
+        dispatch(changeStartingHLSStream(false));
         // prebuiltCleanUp();
       }
     }


### PR DESCRIPTION
# Description

user stuck on "starting stream" screen when starting HLS stream attempt fails


### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
