### PR TITLE
RN-148: Stopped sending terminal notification when Screen / Audio share is cancelled

### DIFF
--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSAudioshareActivity.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSAudioshareActivity.kt
@@ -23,7 +23,6 @@ class HMSAudioshareActivity : ComponentActivity() {
             override fun onError(error: HMSException) {
               finish()
               HMSManager.hmsCollection[id]?.audioshareCallback?.reject(error)
-              HMSManager.hmsCollection[id]?.emitHMSError(error)
             }
 
             override fun onSuccess() {
@@ -48,7 +47,6 @@ class HMSAudioshareActivity : ComponentActivity() {
             "RESULT_CANCELED",
           )
         HMSManager.hmsCollection[id]?.audioshareCallback?.reject(error)
-        HMSManager.hmsCollection[id]?.emitHMSError(error)
         finish()
       }
     }

--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HmsScreenshareActivity.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HmsScreenshareActivity.kt
@@ -22,7 +22,6 @@ class HmsScreenshareActivity : ComponentActivity() {
             override fun onError(error: HMSException) {
               finish()
               HMSManager.hmsCollection[id]?.screenshareCallback?.reject(error)
-              HMSManager.hmsCollection[id]?.emitHMSError(error)
             }
 
             override fun onSuccess() {
@@ -45,7 +44,6 @@ class HmsScreenshareActivity : ComponentActivity() {
             "RESULT_CANCELED",
           )
         HMSManager.hmsCollection[id]?.screenshareCallback?.reject(error)
-        HMSManager.hmsCollection[id]?.emitHMSError(error)
         finish()
       }
     }


### PR DESCRIPTION
# Description

- Stopped sending terminal notification when Screen / Audio share is cancelled


### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
