### PR TITLE
RN-182: invoking leave when app is getting killed on iOS

### DIFF
--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
@@ -72,6 +72,10 @@ class HMSManager(reactContext: ReactApplicationContext) :
         reactAppContext?.currentActivity?.enterPictureInPictureMode(pipParams)
       }
     }
+
+    fun onDestroy() {
+      hmsCollection["12345"]?.hmsSDK?.leave(null)
+    }
   }
 
   override fun getName(): String {
@@ -1328,10 +1332,7 @@ class HMSManager(reactContext: ReactApplicationContext) :
     try {
       if (activity.componentName.shortClassName == ".MainActivity") {
         for (key in hmsCollection.keys) {
-          val hmsLocalPeer = hmsCollection[key]?.hmsSDK?.getLocalPeer()
-          if (hmsLocalPeer != null) {
-            hmsCollection[key]?.leave(null)
-          }
+            hmsCollection[key]?.leave(callback = null, fromPIP = false)
         }
         currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
         hmsCollection = mutableMapOf()

--- a/packages/react-native-hms/ios/HMSRNSDK.swift
+++ b/packages/react-native-hms/ios/HMSRNSDK.swift
@@ -58,6 +58,12 @@ class HMSRNSDK: HMSUpdateListener, HMSPreviewListener {
         self.delegate = manager
         self.id = id
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UIApplication.willTerminateNotification,
+                                                  object: nil)
+    }
 
     // MARK: - Prebuilt
 

--- a/packages/react-native-hms/ios/HMSRNSDK.swift
+++ b/packages/react-native-hms/ios/HMSRNSDK.swift
@@ -45,6 +45,15 @@ class HMSRNSDK: HMSUpdateListener, HMSPreviewListener {
                 let audioSettings = HMSHelper.getLocalAudioSettings(trackSettings?.value(forKey: "audio") as? NSDictionary, sdk, self?.delegate, id)
                 sdk.trackSettings = HMSTrackSettings(videoSettings: videoSettings, audioSettings: audioSettings)
             }
+            
+            NotificationCenter.default.addObserver(forName: UIApplication.willTerminateNotification,
+                                                   object: nil,
+                                                   queue: .main) { [weak self] notification in
+                print(#function, notification.name)
+                self?.hms?.leave{ success, error in
+                    print(#function, "leave invoked", success, error as Any)
+                }
+            }
         }
         self.delegate = manager
         self.id = id

--- a/packages/react-native-room-kit/example/android/app/src/main/java/com/rnexample/MainActivity.java
+++ b/packages/react-native-room-kit/example/android/app/src/main/java/com/rnexample/MainActivity.java
@@ -46,4 +46,10 @@ public class MainActivity extends ReactActivity {
     super.onUserLeaveHint();
     HMSManager.Companion.onUserLeaveHint();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    HMSManager.Companion.onDestroy();
+  }
 }


### PR DESCRIPTION
# Description

* invoking leave when app is getting killed on iOS

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
