### PR TITLE
RN-194: Remote Peer Lower Hand not working on Android

### DIFF
--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
@@ -1232,6 +1232,7 @@ class HMSManager(reactContext: ReactApplicationContext) :
     hms?.lowerLocalPeerHand(data, promise)
   }
 
+  @ReactMethod
   fun lowerRemotePeerHand(
     data: ReadableMap,
     promise: Promise?,


### PR DESCRIPTION
# Description

On Android, `hmsInstance.lowerRemotePeerHand` method not working

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I have updated the `ExampleAppChangelog.txt` file with relevant changes.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
