### PR TITLE
RN-196: ios swipe to go back gesture handled

### DIFF
--- a/packages/react-native-room-kit/src/HMSContainer.tsx
+++ b/packages/react-native-room-kit/src/HMSContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 
 import type { RootState } from './redux';
 import { HMSInstanceSetup } from './HMSInstanceSetup';
@@ -8,22 +8,28 @@ import { MeetingState } from './types';
 import { clearStore } from './redux/actions';
 
 export const HMSContainer = () => {
+  const store = useStore<RootState>();
   const dispatch = useDispatch();
-  const isHMSInstanceAvailable = useSelector(
-    (state: RootState) => !!state.user.hmsInstance
-  );
-  const outOfMeeting = useSelector(
-    (state: RootState) => state.app.meetingState === MeetingState.EXITED
-  );
-  const canCleanupAfter = isHMSInstanceAvailable && outOfMeeting;
+  const hmsInstance = useSelector((state: RootState) => state.user.hmsInstance);
 
   React.useEffect(() => {
-    if (canCleanupAfter) {
-      return () => {
+    if (hmsInstance) {
+      const cleanup = async () => {
+        const userExited =
+          store.getState().app.meetingState === MeetingState.EXITED;
+        if (!userExited) {
+          await hmsInstance.leave();
+          await hmsInstance.destroy();
+        }
         dispatch(clearStore());
       };
+      return () => {
+        cleanup();
+      };
     }
-  }, [canCleanupAfter]);
+  }, [hmsInstance, store]);
+
+  const isHMSInstanceAvailable = !!hmsInstance;
 
   if (isHMSInstanceAvailable) {
     return <HMSRoomSetup />;


### PR DESCRIPTION
# Description

leave and destroy apis were not called when user go back by swiping the screen

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I have updated the `ExampleAppChangelog.txt` file with relevant changes.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->

[Documentation]: https://www.100ms.live/docs
