### PR TITLE
Hide "Tap to FullScreen" button on Screenshare when in Landscape mode

### DIFF
--- a/packages/react-native-room-kit/example/ExampleAppChangelog.txt
+++ b/packages/react-native-room-kit/example/ExampleAppChangelog.txt
@@ -6,6 +6,9 @@ https://100ms.atlassian.net/browse/RN-219
 - Gaayak - Make landscape mode same as Gmeet as default
 https://100ms.atlassian.net/browse/RN-217
 
+- Hide "Tap to FullScreen" button on Screenshare when in Landscape mode
+https://100ms.atlassian.net/browse/RN-220
+
 Room Kit: 1.0.9
 React Native SDK: 1.9.8
 Android SDK: 2.9.0

--- a/packages/react-native-room-kit/src/components/PeerVideoTile/PeerVideoTileView.tsx
+++ b/packages/react-native-room-kit/src/components/PeerVideoTile/PeerVideoTileView.tsx
@@ -28,6 +28,7 @@ import {
 import { useHMSRoomStyleSheet } from '../../hooks-util';
 import { HMSFullScreenButton } from './HMSFullScreenButton';
 import { TestIds } from '../../utils/constants';
+import { useIsLandscapeOrientation } from '../../utils/dimension';
 
 export interface PeerVideoTileViewProps {
   peerTrackNode: PeerTrackNode;
@@ -146,6 +147,8 @@ export const _PeerVideoTileView = React.forwardRef<
       !canTakeActionOnPeer || // If local peer can't take action on peer, Or
       !allowedToPublish; // If local peer can't publish tracks
 
+    const isLandscapeOrientation = useIsLandscapeOrientation();
+
     return (
       <View style={styles.container}>
         <AvatarView
@@ -181,7 +184,7 @@ export const _PeerVideoTileView = React.forwardRef<
 
         {/* Handling Peer Audio Mute indicator */}
         {screenShareTile && showingVideoTrack ? (
-          isPipModeActive ? null : (
+          isPipModeActive || isLandscapeOrientation ? null : (
             <HMSFullScreenButton peerTrackNode={peerTrackNode} />
           )
         ) : peerCanPublishAudio ? (


### PR DESCRIPTION
# Description

- RN-220: Hide "Tap to FullScreen" button on Screenshare when in Landscape mode

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I have updated the `ExampleAppChangelog.txt` file with relevant changes.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->

[Documentation]: https://www.100ms.live/docs
