### PR TITLE
fixed react native 81 sdk compatibility issues

### DIFF
--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSHLSPlayerManager.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSHLSPlayerManager.kt
@@ -24,15 +24,18 @@ class HMSHLSPlayerManager : SimpleViewManager<HMSHLSPlayer>() {
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
     super.getExportedCustomDirectEventTypeConstants()
 
-    return MapBuilder.of(
-      HMSHLSPlayerConstants.HMS_HLS_PLAYBACK_EVENT,
-      MapBuilder.of("registrationName", "onHmsHlsPlaybackEvent"),
-      HMSHLSPlayerConstants.HMS_HLS_STATS_EVENT,
-      MapBuilder.of("registrationName", "onHmsHlsStatsEvent"),
-      HMSHLSPlayerConstants.HLS_DATA_REQUEST_EVENT,
-      MapBuilder.of("registrationName", "onDataReturned"),
-      HMSHLSPlayerConstants.HLS_PLAYER_CUES_EVENT,
-      MapBuilder.of("registrationName", "onHlsPlayerCuesEvent"),
+    // MapBuilder returns a Java Map; wrap it into a MutableMap to satisfy RN 0.81 signature
+    return HashMap(
+      MapBuilder.of(
+        HMSHLSPlayerConstants.HMS_HLS_PLAYBACK_EVENT,
+        MapBuilder.of("registrationName", "onHmsHlsPlaybackEvent"),
+        HMSHLSPlayerConstants.HMS_HLS_STATS_EVENT,
+        MapBuilder.of("registrationName", "onHmsHlsStatsEvent"),
+        HMSHLSPlayerConstants.HLS_DATA_REQUEST_EVENT,
+        MapBuilder.of("registrationName", "onDataReturned"),
+        HMSHLSPlayerConstants.HLS_PLAYER_CUES_EVENT,
+        MapBuilder.of("registrationName", "onHlsPlayerCuesEvent"),
+      ),
     )
   }
 
@@ -97,22 +100,24 @@ class HMSHLSPlayerManager : SimpleViewManager<HMSHLSPlayer>() {
   }
 
   override fun getCommandsMap(): MutableMap<String, Int>? =
-    MapBuilder
-      .builder<String, Int>()
-      .put("play", 10)
-      .put("stop", 20)
-      .put("pause", 30)
-      .put("resume", 40)
-      .put("seekToLivePosition", 50)
-      .put("seekForward", 60)
-      .put("seekBackward", 70)
-      .put("setVolume", 80)
-      .put("areClosedCaptionSupported", 90)
-      .put("isClosedCaptionEnabled", 100)
-      .put("enableClosedCaption", 110)
-      .put("disableClosedCaption", 120)
-      .put("getPlayerDurationDetails", 130)
-      .build()
+    HashMap(
+      MapBuilder
+        .builder<String, Int>()
+        .put("play", 10)
+        .put("stop", 20)
+        .put("pause", 30)
+        .put("resume", 40)
+        .put("seekToLivePosition", 50)
+        .put("seekForward", 60)
+        .put("seekBackward", 70)
+        .put("setVolume", 80)
+        .put("areClosedCaptionSupported", 90)
+        .put("isClosedCaptionEnabled", 100)
+        .put("enableClosedCaption", 110)
+        .put("disableClosedCaption", 120)
+        .put("getPlayerDurationDetails", 130)
+        .build(),
+    )
 
   @ReactProp(name = "url")
   fun setStreamURL(

--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
@@ -96,7 +96,7 @@ class HMSManager(
       reactAppContext = reactApplicationContext
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        currentActivity?.let {
+        reactApplicationContext.currentActivity?.let {
           pipReceiver?.register(it)
         }
       }
@@ -438,7 +438,7 @@ class HMSManager(
     data: ReadableMap,
     callback: Promise?,
   ) {
-    currentActivity?.application?.registerActivityLifecycleCallbacks(this)
+  reactApplicationContext.currentActivity?.application?.registerActivityLifecycleCallbacks(this)
     val hms = HMSHelper.getHms(data, hmsCollection)
 
     hms?.startScreenshare(callback)
@@ -461,7 +461,7 @@ class HMSManager(
   ) {
     val hms = HMSHelper.getHms(data, hmsCollection)
 
-    currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
+  reactApplicationContext.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
     hms?.stopScreenshare(callback)
   }
 
@@ -470,7 +470,7 @@ class HMSManager(
     data: ReadableMap,
     callback: Promise?,
   ) {
-    currentActivity?.application?.registerActivityLifecycleCallbacks(this)
+  reactApplicationContext.currentActivity?.application?.registerActivityLifecycleCallbacks(this)
     val hms = HMSHelper.getHms(data, hmsCollection)
 
     hms?.startAudioshare(data, callback)
@@ -493,7 +493,7 @@ class HMSManager(
   ) {
     val hms = HMSHelper.getHms(data, hmsCollection)
 
-    currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
+  reactApplicationContext.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
     hms?.stopAudioshare(callback)
   }
 
@@ -784,7 +784,7 @@ class HMSManager(
       return
     }
 
-    val activity = currentActivity
+  val activity = reactApplicationContext.currentActivity
 
     if (activity !== null) {
       val hmssdk = getHmsInstance()[PipActionReceiver.sdkIdForPIP!!]?.hmsSDK
@@ -1085,7 +1085,7 @@ class HMSManager(
         throw Throwable(message = "PIP Mode is not supported!")
       }
 
-      val activity = currentActivity ?: return false
+  val activity = reactApplicationContext.currentActivity ?: return false
       val pipParamConfig = readableMapToPipParamConfig(data) ?: return false
       val pipParams = buildPipParams(pipParamConfig) ?: return false
 
@@ -1122,7 +1122,7 @@ class HMSManager(
         throw Throwable(message = "PIP Mode is not supported!")
       }
 
-      val activity = currentActivity ?: return false
+  val activity = reactApplicationContext.currentActivity ?: return false
       val pipParamConfig = readableMapToPipParamConfig(data) ?: return false
       val pipParams = buildPipParams(pipParamConfig) ?: return false
 
@@ -1713,7 +1713,7 @@ class HMSManager(
             hmsCollection[key]?.leave(null)
           }
         }
-        currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
+  reactApplicationContext.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
         hmsCollection = mutableMapOf()
         // unregistering pip actions on activity destroy.
         if (pipReceiver !== null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSSDKViewManager.kt
+++ b/packages/react-native-hms/android/src/main/java/com/reactnativehmssdk/HMSSDKViewManager.kt
@@ -22,17 +22,21 @@ class HMSSDKViewManager : SimpleViewManager<HMSView>() {
   }
 
   override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any>? =
-    MapBuilder
-      .builder<String, Any>()
-      .put(
-        "topChange",
-        MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onChange")),
-      ).build()
+    HashMap(
+      MapBuilder
+        .builder<String, Any>()
+        .put(
+          "topChange",
+          MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onChange")),
+        ).build(),
+    )
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? =
-    MapBuilder.of(
-      "captureFrame",
-      MapBuilder.of("registrationName", "onDataReturned"),
+    HashMap(
+      MapBuilder.of(
+        "captureFrame",
+        MapBuilder.of("registrationName", "onDataReturned"),
+      ),
     )
 
   @RequiresApi(Build.VERSION_CODES.N)


### PR DESCRIPTION
This pull request updates the React Native HMS Android module to improve compatibility with React Native 0.81 by ensuring that event and command maps are returned as `MutableMap` instances. It also refactors the usage of the current activity throughout `HMSManager` to consistently use `reactApplicationContext.currentActivity`, which is a more reliable way to access the current activity in React Native modules.

### React Native 0.81 compatibility improvements

* Updated `getExportedCustomDirectEventTypeConstants`, `getExportedCustomBubblingEventTypeConstants`, and `getCommandsMap` in `HMSHLSPlayerManager` and `HMSSDKViewManager` to wrap maps with `HashMap`, ensuring the returned type matches the expected `MutableMap` signature for React Native 0.81. [[1]](diffhunk://#diff-48321bad63419fa5d580123c103c50055c1367502e89b3237202fc622f9b6ecfL27-R29) [[2]](diffhunk://#diff-48321bad63419fa5d580123c103c50055c1367502e89b3237202fc622f9b6ecfR38) [[3]](diffhunk://#diff-48321bad63419fa5d580123c103c50055c1367502e89b3237202fc622f9b6ecfR103) [[4]](diffhunk://#diff-48321bad63419fa5d580123c103c50055c1367502e89b3237202fc622f9b6ecfL115-R120) [[5]](diffhunk://#diff-922af2352197b9bfd5922299f91b68bc916d3770fbf7dddbac9b0c6180669051R25-R39)

### Activity access refactoring

* Replaced all instances of `currentActivity` with `reactApplicationContext.currentActivity` in `HMSManager`, making activity access more robust and preventing potential null pointer issues. This change affects PIP registration, screenshare, audioshare, and lifecycle callback registration/unregistration. [[1]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL99-R99) [[2]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL441-R441) [[3]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL464-R464) [[4]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL473-R473) [[5]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL496-R496) [[6]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL787-R787) [[7]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL1088-R1088) [[8]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL1125-R1125) [[9]](diffhunk://#diff-82a73c943dd7d79e742815c5c5112889b6a9ccdb0dfd99880deaed835b318efdL1716-R1716)