### PR TITLE
chore(release): @100mslive/react-native-hms 1.12.1

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

Patch release of `@100mslive/react-native-hms` containing the Kotlin 2.x / RN 0.81+ Android build fix.

- Bumps `packages/react-native-hms/package.json` version: `1.12.0` → `1.12.1`
- Sole change in this release: PR #1609 (`fix(android): support Kotlin 2.x and modern RN compat`)

iOS podspec auto-tracks `package.json` (`s.version = package["version"]`), so no manual podspec edit needed.

## Order of releases

This is **release 1 of 2**. After this is merged and published to npm:
1. ✅ `@100mslive/react-native-hms@1.12.1` — this PR
2. ⏭ `@100mslive/react-native-room-kit@1.3.1` — bumps its hms dep from `1.12.0` → `1.12.1` (separate PR, opened after this publishes)

room-kit pins hms exactly (`"@100mslive/react-native-hms": "1.12.0"`), so room-kit consumers won't pick up the fix until room-kit is also republished against the new hms.
