### PR TITLE
chore(release): @100mslive/react-native-room-kit 1.3.1

### DIFF
--- a/packages/react-native-room-kit/package.json
+++ b/packages/react-native-room-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-room-kit",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -153,7 +153,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@100mslive/react-native-hms": "1.12.0",
+    "@100mslive/react-native-hms": "1.12.1",
     "@react-native-community/blur": "^4.4.0",
     "@react-native-masked-view/masked-view": "^0.3.0",
     "@react-navigation/native": "^6.1.0",


### PR DESCRIPTION
## Summary
- Bump `@100mslive/react-native-room-kit` from `1.3.0` → `1.3.1`
- Bump peer dependency `@100mslive/react-native-hms` from `1.12.0` → `1.12.1` to align with the just-published hms release

Patch release covering the maintenance / CVE / dependency work that has accumulated since `1.3.0` (node-forge, fast-xml-parser, vm2, tar, TS warning fixes, autolinking + metro config tweaks).

## Test plan
- [ ] CI passes
- [ ] After merge: `npm run prepack` and `npm publish` from `packages/react-native-room-kit`
- [ ] Verify `npm view @100mslive/react-native-room-kit version` returns `1.3.1`
- [ ] Tag `react-native-room-kit-1.3.1` on the merge commit