### PR TITLE
feat: add native SDK version validation + bump workflow (mirrors Flutter PR #1853)

### DIFF
--- a/.claude/skills/update-sdk-versions.md
+++ b/.claude/skills/update-sdk-versions.md
@@ -56,10 +56,13 @@ Add `--ios-broadcast`, `--ios-hls`, `--ios-noise-cancel` when the user has provi
 2. Bumps `packages/react-native-hms/package.json` and its example.
 3. Bumps `packages/react-native-room-kit/package.json` and its example.
 4. **Always** sets `peerDependencies['@100mslive/react-native-hms']` in room-kit's `package.json` to the resolved hms version (auto-corrects drift, even when `--hms-bump=skip`).
-5. Runs `npm install` in the four affected directories in parallel to refresh lock files.
-6. Runs `node scripts/update-changelog-versions.js` to refresh the version block at the bottom of `ExampleAppChangelog.txt`.
-7. Prints a suggested conventional-commit message.
-8. Reminds you to `pod install` if any iOS native version changed (Podfile.lock isn't touched by `npm install`).
+5. **Validates iOS native versions** by HEAD-checking each pod (`HMSSDK`, `HMSBroadcastExtensionSDK`, `HMSHLSPlayerSDK`, `HMSNoiseCancellationModels`) against the CocoaPods CDN (only if any iOS native field changed). If a version doesn't exist, the script exits non-zero with a clear error.
+6. **Validates the Android native version** by HEAD-checking the `live.100ms:android-sdk`, `:video-view`, and `:hls-player` artifacts on Maven Central (only if `--android-sdk` changed).
+7. After validation passes, runs `npm install --legacy-peer-deps` in 4 dirs to refresh lock files (the `--legacy-peer-deps` flag tolerates a known monorepo peer-dep drift between react-native-video-plugin and react-native-hms).
+8. Runs `pod install --repo-update` in both iOS example dirs and `./gradlew :app:dependencies --refresh-dependencies` in both Android example dirs (side-effect refresh; HTTP HEAD above is the actual validator since pod install reuses Podfile.lock).
+9. All native validation/refresh is skipped by `--no-install`. On validation failure the script aborts; revert with `git checkout .`.
+10. Runs `node scripts/update-changelog-versions.js` to refresh the version block at the bottom of `ExampleAppChangelog.txt`.
+11. Prints a suggested conventional-commit message.
 
 ## After the script completes
 

--- a/.github/workflows/bump-sdk-versions.yml
+++ b/.github/workflows/bump-sdk-versions.yml
@@ -1,0 +1,170 @@
+name: Bump SDK Versions
+
+# Manually-triggered workflow to bump 100ms native SDK versions and React
+# Native package versions in lock-step, then open a PR with the changes
+# (including refreshed package-lock.json files).
+#
+# See scripts/update-sdk-versions.js for the script behaviour and flag list.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ios_sdk:
+        description: "iOS HMSSDK version (leave blank to keep current)"
+        required: false
+        type: string
+      android_sdk:
+        description: "Android HMSSDK version (leave blank to keep current)"
+        required: false
+        type: string
+      ios_broadcast:
+        description: "iOSBroadcastExtension version (blank = keep)"
+        required: false
+        type: string
+      ios_hls:
+        description: "iOSHMSHLSPlayer version (blank = keep)"
+        required: false
+        type: string
+      ios_noise_cancel:
+        description: "iOSNoiseCancellationModels version (blank = keep)"
+        required: false
+        type: string
+      hms_bump:
+        description: "Bump @100mslive/react-native-hms"
+        required: true
+        type: choice
+        default: skip
+        options: [skip, patch, minor, major]
+      room_kit_bump:
+        description: "Bump @100mslive/react-native-room-kit"
+        required: true
+        type: choice
+        default: skip
+        options: [skip, patch, minor, major]
+
+concurrency:
+  group: bump-sdk-versions
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run update-sdk-versions.js
+        run: |
+          set -euo pipefail
+          ARGS=(--hms-bump "${{ inputs.hms_bump }}" --room-kit-bump "${{ inputs.room_kit_bump }}" --yes --no-install)
+          [ -n "${{ inputs.ios_sdk }}" ]          && ARGS+=(--ios-sdk "${{ inputs.ios_sdk }}")
+          [ -n "${{ inputs.android_sdk }}" ]      && ARGS+=(--android-sdk "${{ inputs.android_sdk }}")
+          [ -n "${{ inputs.ios_broadcast }}" ]    && ARGS+=(--ios-broadcast "${{ inputs.ios_broadcast }}")
+          [ -n "${{ inputs.ios_hls }}" ]          && ARGS+=(--ios-hls "${{ inputs.ios_hls }}")
+          [ -n "${{ inputs.ios_noise_cancel }}" ] && ARGS+=(--ios-noise-cancel "${{ inputs.ios_noise_cancel }}")
+          echo "Running: node scripts/update-sdk-versions.js ${ARGS[*]}"
+          node scripts/update-sdk-versions.js "${ARGS[@]}"
+
+      - name: Refresh package-lock.json files (parallel)
+        run: |
+          set -euo pipefail
+          (cd packages/react-native-hms             && npm install --no-audit --no-fund) &
+          (cd packages/react-native-hms/example     && npm install --no-audit --no-fund) &
+          (cd packages/react-native-room-kit        && npm install --no-audit --no-fund) &
+          (cd packages/react-native-room-kit/example && npm install --no-audit --no-fund) &
+          wait
+
+      - name: Validate native versions exist on registries
+        # The script's --no-install flag skipped HTTP validation in the bump
+        # step above (so we could control parallelism). Re-run validation
+        # explicitly here against the now-written sdk-versions.json values.
+        run: |
+          set -euo pipefail
+          node - <<'EOF'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          const sdk = JSON.parse(fs.readFileSync('packages/react-native-hms/sdk-versions.json', 'utf8'));
+          async function head(url) {
+            const c = new AbortController();
+            const t = setTimeout(() => c.abort(), 15000);
+            try { const r = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: c.signal }); return r.ok; }
+            finally { clearTimeout(t); }
+          }
+          function podUrl(n, v) {
+            const m = crypto.createHash('md5').update(n).digest('hex');
+            return `https://cdn.cocoapods.org/Specs/${m[0]}/${m[1]}/${m[2]}/${n}/${v}/${n}.podspec.json`;
+          }
+          (async () => {
+            const checks = [
+              ['HMSSDK', sdk.ios],
+              ['HMSBroadcastExtensionSDK', sdk.iOSBroadcastExtension],
+              ['HMSHLSPlayerSDK', sdk.iOSHMSHLSPlayer],
+              ['HMSNoiseCancellationModels', sdk.iOSNoiseCancellationModels],
+            ];
+            let bad = false;
+            for (const [n, v] of checks) {
+              const ok = await head(podUrl(n, v));
+              console.log(`  ${ok ? '✓' : '✗'} ${n} ${v}`);
+              if (!ok) bad = true;
+            }
+            for (const a of ['android-sdk', 'video-view', 'hls-player']) {
+              const url = `https://repo1.maven.org/maven2/live/100ms/${a}/${sdk.android}/${a}-${sdk.android}.pom`;
+              const ok = await head(url);
+              console.log(`  ${ok ? '✓' : '✗'} live.100ms:${a}:${sdk.android}`);
+              if (!ok) bad = true;
+            }
+            if (bad) { console.error('Native version validation failed.'); process.exit(1); }
+          })();
+          EOF
+
+      - name: Show diff summary
+        run: |
+          echo "### Diff summary"
+          git diff --stat
+          echo
+          echo "### Changed files"
+          git diff --name-only
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sdk-version-bump
+          delete-branch: true
+          commit-message: "chore: bump native SDK versions and React Native packages"
+          title: "chore: bump native SDK versions and React Native packages"
+          body: |
+            Automated SDK version bump triggered via `workflow_dispatch`.
+
+            ### Inputs
+            - iOS HMSSDK: `${{ inputs.ios_sdk }}` (blank = unchanged)
+            - Android HMSSDK: `${{ inputs.android_sdk }}` (blank = unchanged)
+            - iOSBroadcastExtension: `${{ inputs.ios_broadcast }}`
+            - iOSHMSHLSPlayer: `${{ inputs.ios_hls }}`
+            - iOSNoiseCancellationModels: `${{ inputs.ios_noise_cancel }}`
+            - @100mslive/react-native-hms bump: `${{ inputs.hms_bump }}`
+            - @100mslive/react-native-room-kit bump: `${{ inputs.room_kit_bump }}`
+
+            ### What changed
+            - `packages/react-native-hms/sdk-versions.json` (native SDK versions; iOS Podspec + Android build.gradle read this programmatically)
+            - `packages/react-native-hms/package.json` + `example/package.json`
+            - `packages/react-native-room-kit/package.json` (incl. peerDep auto-sync) + `example/package.json`
+            - 4 × `package-lock.json` files refreshed by `npm install`
+            - `packages/react-native-room-kit/example/ExampleAppChangelog.txt` "Current Version Info" block
+
+            ### Reviewer checklist
+            - [ ] Verify versions match the intended 100ms SDK release
+            - [ ] If iOS native versions changed, the consumer of this PR should run `pod install` under both `packages/react-native-hms/example/ios` and `packages/react-native-room-kit/example/ios` after pulling
+            - [ ] CI build passes
+
+            🤖 Generated by [`scripts/update-sdk-versions.js`](../blob/main/scripts/update-sdk-versions.js)

--- a/scripts/update-sdk-versions.js
+++ b/scripts/update-sdk-versions.js
@@ -70,10 +70,22 @@ Behavior:
 Side-effects:
   - room-kit's peerDependencies['@100mslive/react-native-hms'] is always
     synced to the resolved hms version (auto-corrects drift).
-  - After writes, runs npm install in 4 dirs (parallel) to refresh lock files.
+  - Validates iOS native versions by HEAD-checking each pod against the
+    CocoaPods CDN; aborts on any 404 (only when iOS native fields changed).
+  - Validates the Android native version by HEAD-checking the live.100ms
+    artifacts on Maven Central (only when --android-sdk changed).
+  - After validation passes, runs npm install in 4 dirs (parallel) to
+    refresh lock files. Uses --legacy-peer-deps to tolerate pre-existing
+    peer-dep mismatches in the monorepo.
+  - Then runs 'pod install --repo-update' in both iOS example dirs and
+    './gradlew :app:dependencies --refresh-dependencies' in both Android
+    example dirs to refresh lock files. These are side-effect refreshes;
+    the HTTP HEAD checks above are the actual validators.
+  - All native validation/refresh skipped with --no-install. On validation
+    failure the script aborts; revert with 'git checkout .' since the
+    dirty-tree guard ensures the working tree was clean on entry.
   - Then runs scripts/update-changelog-versions.js to refresh the version
     block at the bottom of ExampleAppChangelog.txt.
-  - Reminds you to 'pod install' if iOS native versions changed.
 `);
 }
 
@@ -157,7 +169,11 @@ function npmInstallParallel(dirs) {
   const procs = dirs.map((dir) => {
     const cwd = path.join(ROOT, dir);
     return new Promise((resolve, reject) => {
-      const child = spawn('npm', ['install', '--no-audit', '--no-fund'], {
+      // --legacy-peer-deps tolerates the pre-existing peer-dep mismatches in
+      // this monorepo (e.g. react-native-video-plugin pinning an older
+      // react-native-hms peer). Without it, every bump that touches the peer
+      // dep auto-correction would fail npm install on otherwise-fine state.
+      const child = spawn('npm', ['install', '--no-audit', '--no-fund', '--legacy-peer-deps'], {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
@@ -176,6 +192,154 @@ function npmInstallParallel(dirs) {
     });
   });
   return Promise.all(procs);
+}
+
+// ----------------------------------------------------------------------------
+// NATIVE VERSION VALIDATION
+// ----------------------------------------------------------------------------
+//
+// Two stages when iOS or Android native fields change:
+//
+// 1. PRIMARY VALIDATOR: registry-existence check via HTTPS HEAD against the
+//    CocoaPods CDN / Maven Central. Fast (~200ms each) and catches the
+//    most common failure mode: a typo'd version that doesn't exist (e.g.
+//    1.17.2 when the latest published is 1.17.1).
+//
+//    Why not just rely on `pod install`? `pod install` reuses Podfile.lock
+//    when the lockfile is satisfiable, so a Podspec change pointing at a
+//    non-existent version can be silently swallowed. The HTTP HEAD check
+//    is the source of truth.
+//
+// 2. SIDE-EFFECT REFRESH: after the HTTP check passes, run
+//    `pod install --repo-update` and `./gradlew :app:dependencies
+//    --refresh-dependencies`. These don't reliably re-validate the
+//    HMSSDK version (see (1)) but they DO refresh other lock entries
+//    (Firebase, transitive deps).
+//
+// Both stages are skipped entirely with --no-install. Validation runs
+// BEFORE npm install in the main flow so a wrong version aborts in
+// ~200ms instead of waiting for pkg manager resolution.
+
+async function httpExists(url) {
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), 15000);
+    try {
+      const res = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal });
+      return res.ok;
+    } finally {
+      clearTimeout(t);
+    }
+  } catch {
+    return false;
+  }
+}
+
+function cocoapodsCdnUrl(podName, version) {
+  const md5hex = require('crypto').createHash('md5').update(podName).digest('hex');
+  const a = md5hex[0], b = md5hex[1], c = md5hex[2];
+  return `https://cdn.cocoapods.org/Specs/${a}/${b}/${c}/${podName}/${version}/${podName}.podspec.json`;
+}
+
+function mavenCentralPomUrl(groupPath, artifact, version) {
+  return `https://repo1.maven.org/maven2/${groupPath}/${artifact}/${version}/${artifact}-${version}.pom`;
+}
+
+async function validateIosNativeVersions(targets) {
+  const pods = [
+    ['HMSSDK', targets.ios],
+    ['HMSBroadcastExtensionSDK', targets.iOSBroadcastExtension],
+    ['HMSHLSPlayerSDK', targets.iOSHMSHLSPlayer],
+    ['HMSNoiseCancellationModels', targets.iOSNoiseCancellationModels],
+  ];
+  console.log('\nVerifying iOS native versions exist on CocoaPods CDN...');
+  const results = await Promise.all(
+    pods.map(async ([name, version]) => ({
+      name, version, ok: await httpExists(cocoapodsCdnUrl(name, version)),
+    }))
+  );
+  let failed = false;
+  for (const r of results) {
+    if (r.ok) console.log(`  ✓ ${r.name} ${r.version}`);
+    else { console.log(`  ✗ ${r.name} ${r.version} — not found on CocoaPods CDN`); failed = true; }
+  }
+  if (failed) {
+    throw new Error(
+      'One or more iOS native versions don\'t exist on CocoaPods. ' +
+      'Check the latest available versions on https://cocoapods.org'
+    );
+  }
+}
+
+async function validateAndroidNativeVersion(targets) {
+  const artifacts = ['android-sdk', 'video-view', 'hls-player'];
+  console.log('\nVerifying Android native version exists on Maven Central...');
+  const results = await Promise.all(
+    artifacts.map(async (a) => ({
+      a, ok: await httpExists(mavenCentralPomUrl('live/100ms', a, targets.android)),
+    }))
+  );
+  let failed = false;
+  for (const r of results) {
+    if (r.ok) console.log(`  ✓ live.100ms:${r.a}:${targets.android}`);
+    else { console.log(`  ✗ live.100ms:${r.a}:${targets.android} — not found on Maven Central`); failed = true; }
+  }
+  if (failed) {
+    throw new Error(
+      'One or more Android native artifacts don\'t exist on Maven Central. ' +
+      'Check https://central.sonatype.com/artifact/live.100ms/android-sdk'
+    );
+  }
+}
+
+// Side-effect lock-file refresh (NOT a validator — see big comment above).
+async function refreshPodLockfiles(iosDirs) {
+  for (const rel of iosDirs) {
+    const cwd = path.join(ROOT, rel);
+    if (!fs.existsSync(cwd)) {
+      console.log(`  (skip) ${rel} — directory missing`);
+      continue;
+    }
+    console.log(`\nRefreshing Podfile.lock in ${rel} via pod install --repo-update (this can take a few minutes)...`);
+    await new Promise((resolve) => {
+      const child = spawn('pod', ['install', '--repo-update'], { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      child.stdout.on('data', () => {});
+      let stderr = '';
+      child.stderr.on('data', (d) => (stderr += d.toString()));
+      child.on('close', (code) => {
+        if (code === 0) console.log(`  ✓ ${rel}`);
+        else { console.warn(`  ⚠ pod install in ${rel} exited ${code}; review manually.`); if (stderr) console.warn(stderr.slice(-500)); }
+        resolve();
+      });
+      child.on('error', (e) => { console.warn(`  ⚠ pod CLI not available or failed: ${e.message}`); resolve(); });
+    });
+  }
+}
+
+async function refreshGradleDependencies(androidDirs) {
+  for (const rel of androidDirs) {
+    const cwd = path.join(ROOT, rel);
+    const gradlew = path.join(cwd, 'gradlew');
+    if (!fs.existsSync(cwd) || !fs.existsSync(gradlew)) {
+      console.log(`  (skip) ${rel} — directory or gradlew missing`);
+      continue;
+    }
+    console.log(`\nRefreshing Android dependencies in ${rel} via gradle (this can take a few minutes)...`);
+    await new Promise((resolve) => {
+      const child = spawn('./gradlew', [':app:dependencies', '--refresh-dependencies', '--quiet'], {
+        cwd, stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout.on('data', () => {});
+      let stderr = '';
+      child.stderr.on('data', (d) => (stderr += d.toString()));
+      child.on('close', (code) => {
+        if (code === 0) console.log(`  ✓ ${rel}`);
+        else { console.warn(`  ⚠ gradle :app:dependencies in ${rel} exited ${code}; review manually.`); if (stderr) console.warn(stderr.slice(-500)); }
+        resolve();
+      });
+      child.on('error', (e) => { console.warn(`  ⚠ gradlew not executable or failed: ${e.message}`); resolve(); });
+    });
+  }
 }
 
 async function main() {
@@ -356,10 +520,41 @@ async function main() {
     console.log(`✓ wrote ${path.relative(ROOT, PATHS.roomKitExamplePkg)}`);
   }
 
+  // Native version validation runs BEFORE npm install so a wrong version
+  // aborts in ~200ms instead of waiting for the (potentially slow / flaky)
+  // npm peer-dep resolution. Skipped entirely with --no-install.
+  const iosNativeChanged =
+    !!sdkDiff.ios ||
+    !!sdkDiff.iOSBroadcastExtension ||
+    !!sdkDiff.iOSHMSHLSPlayer ||
+    !!sdkDiff.iOSNoiseCancellationModels;
+  const androidNativeChanged = !!sdkDiff.android;
+
+  if (!args.bool['no-install'] && iosNativeChanged) {
+    await validateIosNativeVersions(targetSdk);
+  }
+  if (!args.bool['no-install'] && androidNativeChanged) {
+    await validateAndroidNativeVersion(targetSdk);
+  }
+
   if (!args.bool['no-install']) {
     await npmInstallParallel(INSTALL_DIRS);
   } else {
     console.log('\n(skipped npm install — lock files not refreshed)');
+  }
+
+  // Side-effect lock refresh (after HTTP validation has already passed).
+  if (!args.bool['no-install'] && iosNativeChanged) {
+    await refreshPodLockfiles([
+      'packages/react-native-hms/example/ios',
+      'packages/react-native-room-kit/example/ios',
+    ]);
+  }
+  if (!args.bool['no-install'] && androidNativeChanged) {
+    await refreshGradleDependencies([
+      'packages/react-native-hms/example/android',
+      'packages/react-native-room-kit/example/android',
+    ]);
   }
 
   console.log('\nUpdating ExampleAppChangelog.txt version block...');


### PR DESCRIPTION
## Summary

Brings the `100ms-react-native` SDK updater up to parity with the equivalent shipped in `100ms-flutter` PR #1853. Three additions on top of the SDK updater script (commit `c93fbfe5` already on `dev`):

1. **Native SDK version validation** — primary validator is HTTPS HEAD against the CocoaPods CDN (per pod) and Maven Central (per artifact). Catches typo'd versions in ~200ms before any `npm install` runs. The side-effect refresh (`pod install --repo-update`, `./gradlew :app:dependencies --refresh-dependencies`) runs after.
2. **`.github/workflows/bump-sdk-versions.yml`** — a `workflow_dispatch` GitHub Action that exposes the script via the GitHub UI and opens a PR via `peter-evans/create-pull-request@v6`.
3. **Skill updates** — `.claude/skills/update-sdk-versions.md` now documents the validation behavior so Claude can walk the user through it.

## Why HTTP HEAD instead of `pod install` for validation

`pod install` reuses `Podfile.lock` when the lockfile is already satisfiable, so a Podspec change pointing at a non-existent HMSSDK version can be silently swallowed. The HTTP HEAD against CocoaPods CDN is the source of truth for "does this version exist on the registry". Same finding from Flutter PR #1853 — fully documented in the script's inline comment.

## Other changes

- **`--legacy-peer-deps` on npm install** to tolerate the pre-existing `react-native-video-plugin@1.1.3` ↔ `react-native-hms@1.12.x` peer mismatch in this monorepo. Without this, every bump that runs the peer-dep auto-correction would fail npm install on otherwise-fine state.

## Verification

```
$ node scripts/update-sdk-versions.js --ios-sdk 1.99.99 --hms-bump skip --room-kit-bump skip --yes
  ✗ HMSSDK 1.99.99 — not found on CocoaPods CDN
  ✓ HMSBroadcastExtensionSDK 1.0.1
  ✓ HMSHLSPlayerSDK 0.0.2
  ✓ HMSNoiseCancellationModels 1.0.0
❌ One or more iOS native versions don't exist on CocoaPods.
exit 1
```

## Branching note

This PR is **stacked on `chore/track-claude-skills` (PR #1613)** — it modifies `.claude/skills/update-sdk-versions.md` which is added by that PR. Merge order: #1613 first, then this one. After #1613 merges to `dev`, GitHub will automatically retarget this PR's base to `dev`.

## Test plan

- [x] `--ios-sdk 1.99.99` (nonexistent) — script exits 1 with clear ✗/✓ matrix
- [x] `--ios-sdk 1.17.1` (real latest) — script continues, refreshes Podfile.lock entries
- [x] `--no-install` skips all native validation/refresh
- [x] Help text + skill doc reflect new behavior
- [ ] Smoke-test the workflow via GitHub Actions UI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)