### PR TITLE
chore(release): @100mslive/react-native-hms 1.12.2

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/react-native-room-kit/example/ios/Podfile.lock
+++ b/packages/react-native-room-kit/example/ios/Podfile.lock
@@ -1265,7 +1265,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-hms (1.12.0):
+  - react-native-hms (1.12.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2135,7 +2135,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 1864935968d15b9b73d8e413d29c780f0ab50038
   React-microtasksnativemodule: 3b784cf40f7c3c9500b9a5f9e4eec5c9bbfbef8f
   react-native-blur: b06c3fe88680beac622d8d13b8c36ec15c50383b
-  react-native-hms: a56359002bff27326ad1e88225b34c7ddb3381d6
+  react-native-hms: 826f3f449eca013fc81df40fe1eff92d261ecb7d
   react-native-image-picker: 8c8f120521f283d7a069c51d519fbd654e8de8e3
   react-native-lottie-splash-screen: e7820832f194c296ccdb177a82d8a3f3b7e362bf
   react-native-safe-area-context: 2243039f43d10cb1ea30ec5ac57fc6d1448413f4


### PR DESCRIPTION
## Summary

Patch release that publishes the Phase 0 Interop Layer fix (PR #1616) to npm.

Bumps `@100mslive/react-native-hms` from `1.12.1` → `1.12.2`.

## What customers get in 1.12.2

The Phase 0 changes from #1616:

- **iOS:** `HMSManager.shared` singleton replaces the unreliable `bridge.module(for:)` lookup under New Architecture's Interop Layer
- **Android:** `getNativeModule(HMSManager)` calls now route through `reactApplicationContext` for the same reason

**Customer impact:**

| Customer app config | 1.12.1 (current) | 1.12.2 (this release) |
|---|---|---|
| Old arch (`newArchEnabled=false`) | ✅ works | ✅ works (unchanged) |
| New arch with bridge proxy (RN 0.74–0.81, `bridgeless=false`) | ❌ crashes (#1428) | ✅ **works** |
| New arch bridgeless (RN 0.82+ forces) | ❌ crashes | ⚠️ still requires Phase 1 (`2.0.0`) |

Customers on RN 0.81 with new arch on — the #1428 cohort — are unblocked.

## Files changed

- `packages/react-native-hms/package.json` — version bump (intended change)
- `packages/react-native-room-kit/example/ios/Podfile.lock` — incidental sync with current npm-published `react-native-hms@1.12.1` from an earlier `pod install`. Benign; brings lockfile in line with what's already on npm.

## Release flow after merge

1. Merge this PR
2. From `main`: `cd packages/react-native-hms && npm run prepack && npm publish`
3. Tag `1.12.2` on the merge commit and push the tag

## Verified

- ✅ Old arch regression tested on iOS (simulator) and Android (real device)
- ✅ New arch + interop tested on iOS (yesterday, via `PhaseZeroTestApp`)
- ⚠️ New arch + interop on Android: implicit (Kotlin compiles cleanly; runtime test would require fresh `react-native init` project — deferred to follow-up)