### PR TITLE
ci: add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,46 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1.0.51
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            First read the PR title and description using `gh pr view` to understand the intent and goal of the changes, then review the diff using `gh pr diff`.
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            - Code organization (should any code be moved to other files or extracted into functions?)
+            - Reusability (are we duplicating logic that already exists elsewhere?)
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback. Keep your review concise - focus on the most important issues and avoid lengthy explanations.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code-review.yml` which runs an automated Claude review on every PR open/sync event
- Mirrors the workflow already in use in the `android-sdk-100ms` repo
- Standalone change extracted from `feat/new-arch-phase-1` so the review workflow takes effect on that PR (and all future ones) as soon as this merges

## Test plan
- [ ] Merge to main
- [ ] Verify Claude review runs on a newly opened PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)