### PR TITLE
chore(release): @100mslive/react-native-hms 2.0.0-alpha.0

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.12.2",
+  "version": "2.0.0-alpha.0",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

First alpha release of `@100mslive/react-native-hms` carrying Phase 1 New Architecture support (Fabric + TurboModules + bridgeless), merged via #1630.

## Why 2.0.0-alpha.0

- **Major bump:** Phase 1 introduces a new native architecture (Fabric component views, TurboModule entry points, codegen-driven contract). The public TS API is unchanged for consumers, but the underlying runtime + native surface is a generational shift that warrants signalling via a major version.
- **Alpha suffix:** Full feature-matrix QA (PiP, screen share, HLS, polls, chat, NC, virtual background) isn't complete; some bridgeless-mode edges may still surface in real consumer apps. Alpha lets us iterate as `alpha.1`, `alpha.2`, etc. without committing to a stable `2.0.0` prematurely.
- **`npm publish --tag alpha`:** Should be published under the `alpha` dist-tag so the default `latest` tag continues pointing at the 1.x line for existing customers. Opt-in via `@100mslive/react-native-hms@alpha`.

## What's in this release

Everything from PR #1630:
- TurboModule spec (`src/specs/NativeHMSManager.ts`) + iOS ObjC++ shim (`HMSManager.mm`) + Android `newarch/` source set
- Fabric component specs + view shims (`HMSViewComponentView.mm`, `HMSHLSPlayerComponentView.mm`)
- Android source-set split: shared `*Impl.kt` logic + thin `newarch/` and `oldarch/` wrappers
- Bridgeless-friendly event emission via `UIManagerHelper.getEventDispatcherForReactTag` (replaces the silently-failing `getJSModule(RCTEventEmitter)`)
- iOS view-recycling fixes (HMSView/HMSHLSPlayer `hmsCollection` → computed; HMSViewComponentView prop equality removed)
- 1-arg TurboModule shims for void-typed method signatures (`setLocalMute`, `setLocalVideoMute`)
- JSON serialization error surfacing in HLS event callbacks

## Out of scope

- `@100mslive/react-native-room-kit` version bump and peer-dep update — follows in a separate PR after this alpha is published, so we can iterate on the alpha without churning room-kit.
- Sample apps and the hms package's own example app (RN 0.64) — deferred per the migration plan's Phase 3.