### PR TITLE
chore(release): @100mslive/react-native-hms 2.0.0-alpha.1

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Re-bump to `2.0.0-alpha.1` because `2.0.0-alpha.0` was already published in October 2023 as an abandoned pre-release (taken between 1.8.0 and 1.9.0). npm doesn't allow re-publishing over an existing version.

Contents identical to PR #1640 — Phase 1 New Architecture support. Once merged, publish with `npm publish --tag alpha`.