### PR TITLE
chore(release): @100mslive/react-native-room-kit 2.0.0-alpha.0

### DIFF
--- a/packages/react-native-room-kit/example/android/gradle.properties
+++ b/packages/react-native-room-kit/example/android/gradle.properties
@@ -34,7 +34,7 @@ reactNativeArchitectures=arm64-v8a,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/packages/react-native-room-kit/package.json
+++ b/packages/react-native-room-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-room-kit",
-  "version": "1.3.1",
+  "version": "2.0.0-alpha.0",
   "description": "100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -153,7 +153,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@100mslive/react-native-hms": "1.12.1",
+    "@100mslive/react-native-hms": "2.0.0-alpha.1",
     "@react-native-community/blur": "^4.4.0",
     "@react-native-masked-view/masked-view": "^0.3.0",
     "@react-navigation/native": "^6.1.0",


### PR DESCRIPTION
First alpha release of `@100mslive/react-native-room-kit`, paired with the `@100mslive/react-native-hms@2.0.0-alpha.1` Phase 1 New Architecture release (#1641).

Three changes:
- Bump room-kit version `1.3.1` → `2.0.0-alpha.0`.
- Bump peer dependency on hms `1.12.1` → `2.0.0-alpha.1` (exact pin during the alpha cycle).
- Fix example app `gradle.properties`: `newArchEnabled=false` → `true`. The Phase 1 merge committed the wrong value — gesture-handler 2.31 gates its native CMake build on `isNewArchitectureEnabled()`, so under `newArchEnabled=false` the `libgesturehandler.so` never compiles and the example app crashed on launch with `SoLoaderDSONotFoundError`. Phase 1 Android testing must have been done with the flag temporarily flipped; the committed value was wrong.

Once merged, publish with `npm publish --tag alpha` from `packages/react-native-room-kit`.