### PR TITLE
chore(example/room-kit): bump react-native-video-plugin to ^2.0.0-alpha.0

### DIFF
--- a/packages/react-native-room-kit/example/package-lock.json
+++ b/packages/react-native-room-kit/example/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@100mslive/react-native-hms": "file:../../react-native-hms",
-        "@100mslive/react-native-video-plugin": "1.1.0",
+        "@100mslive/react-native-video-plugin": "^2.0.0-alpha.0",
         "@100mslive/types-prebuilt": "^0.12.12",
         "@react-native-async-storage/async-storage": "1.24.0",
         "@react-native-community/blur": "^4.4.1",
@@ -67,7 +67,7 @@
     },
     "../../react-native-hms": {
       "name": "@100mslive/react-native-hms",
-      "version": "1.12.2",
+      "version": "2.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "zustand": "^4.3.8"
@@ -101,15 +101,15 @@
       "link": true
     },
     "node_modules/@100mslive/react-native-video-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@100mslive/react-native-video-plugin/-/react-native-video-plugin-1.1.0.tgz",
-      "integrity": "sha512-Uv/+sDNHMWo8haTetO/9NneaTRDdmpTASS0pZRKw4Nw/EO/0/cwTlr7xWZ6EQWAnD3n+qLmiCgNT5HMIrSxJGg==",
+      "version": "2.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@100mslive/react-native-video-plugin/-/react-native-video-plugin-2.0.0-alpha.0.tgz",
+      "integrity": "sha512-3qH0CzXTtWWaUYXbjHT6kUZm+yY/dDlEyS+fGFDRMfmRp+8JEvR0bvU/8A/Y3IICQ08nfbK3w+e8NIm05e7YLA==",
       "license": "MIT",
       "workspaces": [
         "example"
       ],
       "peerDependencies": {
-        "@100mslive/react-native-hms": "1.12.0",
+        "@100mslive/react-native-hms": "^2.0.0-alpha.1",
         "react": "*",
         "react-native": "*"
       }

--- a/packages/react-native-room-kit/example/package.json
+++ b/packages/react-native-room-kit/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@100mslive/react-native-hms": "file:../../react-native-hms",
-    "@100mslive/react-native-video-plugin": "1.1.0",
+    "@100mslive/react-native-video-plugin": "^2.0.0-alpha.0",
     "@100mslive/types-prebuilt": "^0.12.12",
     "@react-native-async-storage/async-storage": "1.24.0",
     "@react-native-community/blur": "^4.4.1",


### PR DESCRIPTION
Pairs with the newly published `@100mslive/react-native-video-plugin@2.0.0-alpha.0` (peer-dep on hms widened to `^2.0.0-alpha.1`).

Fixes the ERESOLVE conflict that's been failing CI on the `Build` and `Build (New Architecture)` workflows since #1642:

```
peer @100mslive/react-native-hms@">=1.12.0 <2.0.0" from @100mslive/react-native-video-plugin@1.1.4
Conflicting peer dependency: @100mslive/react-native-hms@2.0.0-alpha.1
```

After this bump:
- video-plugin pulls from npm at `2.0.0-alpha.0`
- Its peer dep `^2.0.0-alpha.1` is satisfied by the example app's local hms tarball
- npm install resolves cleanly

No JS or native code changes — only `package.json` and the regenerated `package-lock.json`.