### PR TITLE
chore(release): @100mslive/react-native-room-kit 2.0.0-alpha.1

### DIFF
--- a/packages/react-native-room-kit/package.json
+++ b/packages/react-native-room-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-room-kit",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -154,7 +154,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@100mslive/react-native-hms": "2.0.0-alpha.1",
+    "@100mslive/react-native-hms": "2.0.0-alpha.2",
     "@react-native-community/blur": "^4.4.0",
     "@react-native-masked-view/masked-view": "^0.3.0",
     "@react-navigation/native": "^6.1.0",


### PR DESCRIPTION
Two-line peer-dep refresh — no source changes.

- room-kit `2.0.0-alpha.0` → `2.0.0-alpha.1`
- `peerDependencies["@100mslive/react-native-hms"]` `2.0.0-alpha.1` → `2.0.0-alpha.2`

Picks up the `use_frameworks!:static` fix from #1648 so that consumers installing the alpha track via `npm install @100mslive/react-native-room-kit@alpha @100mslive/react-native-hms@alpha` automatically get the Expo SDK 54+ unblock.

Once merged, publish from `packages/react-native-room-kit` via:

```bash
npm publish --tag alpha
```