### PR TITLE
fix(android): bump native SDK to 2.9.84 for camera recovery after background (1.12.3)

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/react-native-hms/sdk-versions.json
+++ b/packages/react-native-hms/sdk-versions.json
@@ -3,5 +3,5 @@
   "iOSBroadcastExtension": "1.0.1",
   "iOSHMSHLSPlayer": "0.0.2",
   "iOSNoiseCancellationModels": "1.0.0",
-  "android": "2.9.78"
+  "android": "2.9.84"
 }


### PR DESCRIPTION
## What

Bumps the bundled native Android SDK pin (`react-native-hms/sdk-versions.json`) from `2.9.78` → `2.9.84`. One-line change; targets the `1.12.x` line for a `1.12.3` patch.

## Why

Fixes the camera freeze/black-tile after backgrounding (#1666). When the app is fully backgrounded, Android revokes the camera; the SDK previously only logged it and never restarted capture, so the local peer's video stayed frozen/black for remote peers until a manual mute/unmute. `2.9.84` re-acquires the camera automatically on app foreground.

The actual recovery logic lives in the native SDK — `live.100ms/android-sdk` PR 100mslive/android-sdk#962 (released as `2.9.84`). This RN change just pins to it.

## Validation

- Verified on-device in the RN room-kit example: backgrounding >60s then returning now auto-recovers (no manual mute/unmute), with the SDK's "restarting capture" path firing.
- Native sample app builds & resolves `live.100ms:android-sdk:2.9.84` from Maven Central (`BUILD SUCCESSFUL`).

## Release

Version bump to `1.12.3` (`package.json` + changelog) is handled by **release-it** at release time — not hand-edited here.