### PR TITLE
chore(release): @100mslive/react-native-room-kit 1.3.2 (hms 1.12.3)

### DIFF
--- a/packages/react-native-room-kit/package.json
+++ b/packages/react-native-room-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-room-kit",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -153,7 +153,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@100mslive/react-native-hms": "1.12.1",
+    "@100mslive/react-native-hms": "1.12.3",
     "@react-native-community/blur": "^4.4.0",
     "@react-native-masked-view/masked-view": "^0.3.0",
     "@react-navigation/native": "^6.1.0",


### PR DESCRIPTION
Bumps `@100mslive/react-native-room-kit` to **1.3.2** and its `@100mslive/react-native-hms` **peerDependency** `1.12.1 → 1.12.3`, in lockstep with the hms `1.12.3` release (#1689) — matching the established pattern (e.g. room-kit `1.3.1` bumped the hms peerDep `1.12.0 → 1.12.1`).

This carries the camera-recovery-after-background fix (native SDK `2.9.84`, #1666) to room-kit consumers.

- Single change: `react-native-room-kit/package.json` (version + hms peerDep).
- Branched on top of `release/hms-1.12.3`; published room-kit artifact is unaffected by the base (npm publish packs only the room-kit package).