### PR TITLE
fix(android): bump native SDK to 2.9.84 for camera recovery after background

### DIFF
--- a/packages/react-native-hms/package.json
+++ b/packages/react-native-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/react-native-hms/sdk-versions.json
+++ b/packages/react-native-hms/sdk-versions.json
@@ -3,5 +3,5 @@
   "iOSBroadcastExtension": "1.0.1",
   "iOSHMSHLSPlayer": "0.0.2",
   "iOSNoiseCancellationModels": "1.0.0",
-  "android": "2.9.78"
+  "android": "2.9.84"
 }


### PR DESCRIPTION
Forward-ports to the new-architecture (`main`, `2.0.0-alpha`) line the camera-recovery fix already shipped on the stable line as `1.12.3`.

## What
Bumps `react-native-hms/sdk-versions.json` android pin `2.9.78 → 2.9.84` (one line).

## Why
When the app is fully backgrounded while publishing video, Android revokes the camera; the SDK previously only logged it and never restarted capture, so the local peer's video stayed frozen/black for remote peers until a manual mute/unmute. Native SDK `2.9.84` re-acquires the camera on app foreground. Fixes #1666.

Native SDK change: `live.100ms/android-sdk` 100mslive/android-sdk#962 (released as `2.9.84`, verified resolvable on Maven Central and built against on this repo's example).

## Note
The `2.0.0-alpha` version bump (`package.json`) is intentionally left out — that's handled at alpha-release time, not in this pin bump.