### PR TITLE
chore(release): @100mslive/react-native-room-kit 2.0.0-alpha.2 (hms 2.0.0-alpha.3)

### DIFF
--- a/packages/react-native-room-kit/package.json
+++ b/packages/react-native-room-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-room-kit",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -154,7 +154,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@100mslive/react-native-hms": "2.0.0-alpha.2",
+    "@100mslive/react-native-hms": "2.0.0-alpha.3",
     "@react-native-community/blur": "^4.4.0",
     "@react-native-masked-view/masked-view": "^0.3.0",
     "@react-navigation/native": "^6.1.0",


### PR DESCRIPTION
Bumps `@100mslive/react-native-room-kit` to **2.0.0-alpha.2** and its `@100mslive/react-native-hms` peerDependency `2.0.0-alpha.2 → 2.0.0-alpha.3` — the new-architecture (alpha) counterpart of the stable `room-kit 1.3.2` release (#1696).

Carries the camera-recovery-after-background fix (native SDK `2.9.84`, #1666) to new-arch room-kit consumers, now that `react-native-hms@2.0.0-alpha.3` is published.

- Single change: `react-native-room-kit/package.json` (version + hms peerDep).
- Done as a separate PR after `hms@2.0.0-alpha.3` was published, so the peerDep resolves to a published version.
- Will be published with `npm publish --tag alpha` (stays off `latest`).